### PR TITLE
Cancelling ping_server task potentially kills _conn_lost_cb execution.

### DIFF
--- a/stan/aio/client.py
+++ b/stan/aio/client.py
@@ -562,13 +562,17 @@ class Client:
             except:
                 continue
         self._sub_map = {}
-
+    
     async def _close_due_to_ping(self, err):
-        await self._close()
-        if self._conn_lost_cb is not None:
-            await self._conn_lost_cb(err)
-            self._conn_lost_cb = None
+        
+        async def _shield_close_due_to_ping():
+            await self._close()
+            if self._conn_lost_cb is not None:
+                await self._conn_lost_cb(err)
+                self._conn_lost_cb = None
 
+        await asyncio.shield(_shield_close_due_to_ping(), loop=self._loop)
+        
     async def close(self):
         """
         Close terminates a session with NATS Streaming.

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -560,7 +560,7 @@ class ClientTest(SingleServerTestCase):
 
             self.assertEqual(len(msgs), 10)
             await sc.close()
-
+    
     @async_test
     async def test_ping_responses_trigger_conn_lost_cb(self):
         nc = NATS()
@@ -576,6 +576,10 @@ class ClientTest(SingleServerTestCase):
         received_error_str = ""
         future = asyncio.Future(loop=self.loop)
         async def conn_lost_cb(err):
+            # Added an await on something here, to illustrate that
+            # cancelling the ping-task, used to also cancel this callback.
+            await asyncio.sleep(0.1, loop=self.loop)
+
             nonlocal received_error_str
             received_error_str = str(err)
             future.set_result(True)
@@ -619,6 +623,10 @@ class ClientTest(SingleServerTestCase):
         received_error_str = ""
         future = asyncio.Future(loop=self.loop)
         async def conn_lost_cb(err):
+            # Added an await on something here, to illustrate that
+            # cancelling the ping-task, used to also cancel this callback.
+            await asyncio.sleep(0.1, loop=self.loop)
+            
             nonlocal received_error_str
             received_error_str = str(err)
             future.set_result(True)


### PR DESCRIPTION
Hi there,

We were trying to implement automatic reconnection to STAN when the connection was lost, and ran into an issue with the `conn_lost_cb`.

If you have a couple of awaitable, like calling `stan_client.connect`, the callback stops executing. This is due to, the whole task that is responsible for invoking `conn_lost_cb` (`_ping_server_task`) gets cancelled during the clean up of the client.

Someone with more experience in the code-base and more knowledge of asyncio could surely improve the change. But this is sufficient to be able to implement a retry mechanism.

The fix we have introduced is a shield around `_close_due_to_ping_failure` to allow the callback to full finish its execution.

The issue can easily be reproduced, by introducing an awaitable call inside `conn_lost_cb`, that is long enough for task to register it has been cancelled:

```python
async def conn_lost_cb(err):
  await asyncio.sleep(0.1, loop=self.loop)
  print("This message is often not shown")
```

Notice that this does not only affect `_conn_lost_cb`, but potentially be any of the clean up work in `_close_due_to_ping_failure` after the `_ping_server_task` cancellation.

Cheers

